### PR TITLE
Enable light theme with persistence

### DIFF
--- a/advanced-features.js
+++ b/advanced-features.js
@@ -23,6 +23,7 @@ class AdvancedFeatures {
         this.loadTrafficData();
         this.setupKeyboardShortcuts();
         this.addAdvancedAnalytics();
+        this.setupThemeToggle();
         
         // Update traffic data every hour
         setInterval(() => this.loadTrafficData(), 60 * 60 * 1000);

--- a/style.css
+++ b/style.css
@@ -23,6 +23,16 @@
     --gradient-accent: linear-gradient(135deg, var(--accent-color), var(--primary-color));
 }
 
+/* Light theme overrides */
+.light-theme {
+    --dark-bg: #f2f2f2;
+    --card-bg: #ffffff;
+    --text-primary: #1a202c;
+    --text-secondary: #4a5568;
+    --border-color: #e2e8f0;
+    --shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     background: var(--dark-bg);


### PR DESCRIPTION
## Summary
- add light theme variables in `style.css`
- initialize theme toggle in advanced features script

## Testing
- `node /tmp/test-theme.js`

------
https://chatgpt.com/codex/tasks/task_e_687ada9822688332acf3c2afb7826be3