### PR TITLE
Fix duplicate ID for tasks today stat

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
                 </div>
                 <div class="stats-grid">
                     <div class="stat-item">
-                        <span class="stat-number" id="tasks-today">0</span>
+                        <span class="stat-number" id="stats-tasks-today">0</span>
                         <span class="stat-label">Tarefas Hoje</span>
                     </div>
                     <div class="stat-item">

--- a/script.js
+++ b/script.js
@@ -628,11 +628,11 @@ class PersonalDashboard {
         
         // Update productivity stats
         const today = new Date().toDateString();
-        const tasksToday = this.tasks.filter(t => 
+        const tasksToday = this.tasks.filter(t =>
             new Date(t.createdAt).toDateString() === today
         ).length;
-        
-        document.getElementById('tasks-today').textContent = tasksToday;
+
+        document.getElementById('stats-tasks-today').textContent = tasksToday;
         document.getElementById('focus-time').textContent = `${Math.floor(this.focusTime / 60)}h`;
         
         // Calculate productivity score based on completed tasks and focus time


### PR DESCRIPTION
## Summary
- rename second `tasks-today` element to `stats-tasks-today`
- update script.js to use the new ID in productivity stats

## Testing
- `node` script using `vm` to emulate DOM and calling `updateStats()`

------
https://chatgpt.com/codex/tasks/task_e_687ad982daa88332a098527a3733dc6e