### PR TITLE
Add Google and HERE validation for real-time distances

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Edite as variáveis CSS em `style.css`:
 ### Integrar APIs Externas
 - **Substitua dados simulados** por chamadas reais de API
 - **Adicione chaves de API** nas configurações
+- **Campo "Google Maps API Key"** disponível no menu de endereços
+- **Campo "HERE API Key"** disponível como alternativa
 - **Implemente tratamento de erros** robusto
 - **Configure CORS** se necessário
 


### PR DESCRIPTION
## Summary
- add optional HERE API key to address configuration
- support real distance fetch from Google or HERE
- validate addresses with selected provider
- document HERE API key in README

## Testing
- `node --check address-config.js`


------
https://chatgpt.com/codex/tasks/task_e_687c440e1bb48332a770bd55e36cb564